### PR TITLE
Fix string error

### DIFF
--- a/Languages/English/Keyed/AnimalTab.xml
+++ b/Languages/English/Keyed/AnimalTab.xml
@@ -35,7 +35,7 @@
     <Fluffy.AnimalTab.XHasLearnedYOutOfZ>{0} has learned {1}/{2} of this skill</Fluffy.AnimalTab.XHasLearnedYOutOfZ>
     <Fluffy.AnimalTab.XHasForgottenYOutOfZ>{0} has forgotten {1}/{2} of this skill</Fluffy.AnimalTab.XHasForgottenYOutOfZ>
     <Fluffy.AnimalTab.XIsDesignatedTrainY>{0} is designated to train {1}</Fluffy.AnimalTab.XIsDesignatedTrainY>
-    <Fluffy.AnimalTab.XIsNotDesignatedTrainY>{0} is not designated to train {2}, and will loose the skill over time</Fluffy.AnimalTab.XIsNotDesignatedTrainY>
+    <Fluffy.AnimalTab.XIsNotDesignatedTrainY>{0} is not designated to train {1}, and will lose the skill over time</Fluffy.AnimalTab.XIsNotDesignatedTrainY>
 
     <!-- handler restrictions -->
     <Fluffy.AnimalTab.HandlerX>Handler: {0}</Fluffy.AnimalTab.HandlerX>


### PR DESCRIPTION
<Fluffy.AnimalTab.XIsNotDesignatedTrainY> should only have {0} and {1}.
Note: Korean translation key also appears to need a similar correction.

Fixes string error [1] which occurs at mouseover of any partially
completed (i.e. 1 of 3 training steps), but currently unchecked, animal
skill training checkbox.

Also fixes typo: "lose"

[1] Could not resolve symbol "2" for string "{0} is not designated to train {2}, and will loose the skill over time".