### PR TITLE
Mass Assign Bonded Doesn't Need to Check Handle Skill Anymore

### DIFF
--- a/Source/BetterAnimalsTab/PawnColumns/PawnColumnWorker_Master.cs
+++ b/Source/BetterAnimalsTab/PawnColumns/PawnColumnWorker_Master.cs
@@ -88,8 +88,7 @@ namespace AnimalTab
                 // get bond
                 var bond = animal.relations.GetFirstDirectRelationPawn( PawnRelationDefOf.Bond,
                     p => p.Faction == Faction.OfPlayer );
-                if ( bond == null || bond.skills.GetSkill( SkillDefOf.Animals ).Level <
-                     animal.GetStatValue( StatDefOf.MinimumHandlingSkill ) )
+                if ( bond == null )
                     continue;
                 animal.playerSettings.Master = bond;
             }


### PR DESCRIPTION
## Mass Assign Bonded Doesn't Need to Check Handle Skill Anymore

![20201212015520_1](https://user-images.githubusercontent.com/7416299/101977681-3d97aa80-3c1d-11eb-9524-a9aa469cb745.jpg)

This function currently checks to see whether the Bonded Colonist has sufficient Animals skill for the species before assigning it as Master, because that **used to** be a problem in vanilla - animals would bond to colonists (typically doctors) who didn't have enough Animals skill to be their master.

This is **no longer a problem** in Vanilla. Once bonded, they can be Master regardless of Animals skill.

Here's a colonist with Animals:1 being Master to a Bonded Thrumbo in pure Vanilla: https://imgur.com/a/tLWb0jn